### PR TITLE
make the 4.24 platform LinuxAArch64 configurable

### DIFF
--- a/Unreal Binary Builder/App.config
+++ b/Unreal Binary Builder/App.config
@@ -133,6 +133,9 @@
             <setting name="EngineSelection" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="bWithLinuxAArch64" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Unreal_Binary_Builder.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Unreal Binary Builder/MainWindow.xaml
+++ b/Unreal Binary Builder/MainWindow.xaml
@@ -163,7 +163,7 @@
 			<materialDesign:DialogHost x:Name="AboutDialog" IsOpen="False" CloseOnClickAway="True">
 				<materialDesign:DialogHost.DialogContent>
 					<Grid>
-						<Label x:Name="AboutMessageLabel" Content="A helper application designed to create binary version of Unreal Engine 4 from source.&#xA;&#xA;Created by Satheesh (ryanjon2040)&#xA;&#xA;Updated for 4.18 and PS4/Xbox Support by James Baxter (TheJamsh)&#xA;Updated for 4.21 and Lumin support by KarstenMaxim (AlphaSoftLLC)&#xA;Step counter added by Ben Vaccaro (freaksed)" />
+						<Label x:Name="AboutMessageLabel" Content="A helper application designed to create binary version of Unreal Engine 4 from source.&#xA;&#xA;Created by Satheesh (ryanjon2040)&#xA;&#xA;Updated for 4.18 and PS4/Xbox Support by James Baxter (TheJamsh)&#xA;Updated for 4.21 and Lumin support by KarstenMaxim (AlphaSoftLLC)&#xA;Step counter added by Ben Vaccaro (freaksed)&#xA;Some small updates for 4.24 by Christian Walde (wchristian)" />
 						<Button x:Name="AboutBtn_Ok" VerticalAlignment="Bottom" Margin="10,110,10,10" Content="Ok" Click="AboutBtn_Ok_Click"/>
 					</Grid>
 				</materialDesign:DialogHost.DialogContent>

--- a/Unreal Binary Builder/MainWindow.xaml
+++ b/Unreal Binary Builder/MainWindow.xaml
@@ -59,6 +59,9 @@
 					<Label Content ="Linux" Margin="0,138,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0"/>
 					<ToggleButton x:Name="bWithLinux" Style="{DynamicResource MaterialDesignSwitchToggleButton}" Margin="105,137,0,0" IsEnabled="{Binding IsChecked, Converter={StaticResource NotConverter}, ElementName=bHostPlatformOnly}" HorizontalAlignment="Left" VerticalAlignment="Top"/>
 
+					<Label Content ="LinuxAArch64" Margin="280,137,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0"/>
+					<ToggleButton x:Name="bWithLinuxAArch64" Style="{DynamicResource MaterialDesignSwitchToggleButton}" Margin="357,137,0,0" IsEnabled="{Binding IsChecked, Converter={StaticResource NotConverter}, ElementName=bHostPlatformOnly}" HorizontalAlignment="Left" VerticalAlignment="Top"/>
+
 					<Label Content ="Android" Margin="154,12,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0" />
 					<ToggleButton x:Name="bWithAndroid" Style="{DynamicResource MaterialDesignSwitchToggleButton}" Margin="231,11,0,0" IsEnabled="{Binding IsChecked, Converter={StaticResource NotConverter}, ElementName=bHostPlatformOnly}" HorizontalAlignment="Left" VerticalAlignment="Top"/>
 

--- a/Unreal Binary Builder/MainWindow.xaml.cs
+++ b/Unreal Binary Builder/MainWindow.xaml.cs
@@ -53,6 +53,7 @@ namespace Unreal_Binary_Builder
             bWithWin32.IsChecked = Settings.Default.bWithWin32;
             bWithMac.IsChecked = Settings.Default.bWithMac;
             bWithLinux.IsChecked = Settings.Default.bWithLinux;
+            bWithLinuxAArch64.IsChecked = Settings.Default.bWithLinuxAArch64;
             bWithHTML5.IsChecked = Settings.Default.bWithHTML5;
             bWithAndroid.IsChecked = Settings.Default.bWithAndroid;
             bWithIOS.IsChecked = Settings.Default.bWithIOS;
@@ -164,6 +165,7 @@ namespace Unreal_Binary_Builder
             Settings.Default.bWithWin32 = (bool)bWithWin32.IsChecked;
             Settings.Default.bWithMac = (bool)bWithMac.IsChecked;
             Settings.Default.bWithLinux = (bool)bWithLinux.IsChecked;
+            Settings.Default.bWithLinuxAArch64 = (bool)bWithLinuxAArch64.IsChecked;
             Settings.Default.bWithHTML5 = (bool)bWithHTML5.IsChecked;
             Settings.Default.bWithAndroid = (bool)bWithAndroid.IsChecked;
             Settings.Default.bWithIOS = (bool)bWithIOS.IsChecked;
@@ -479,6 +481,9 @@ namespace Unreal_Binary_Builder
 						GetConditionalString(bWithXboxOne.IsChecked),
 						GetConditionalString(bWithLumin.IsChecked));
 					}
+					if (SupportLinuxAArch64()) {
+						CommandLineArgs += string.Format(" -set:WithLinuxAArch64={0}", GetConditionalString(bWithLinuxAArch64.IsChecked));
+					}
                 }
 
 				if (EngineVersionSelection.SelectedIndex > 1)
@@ -565,6 +570,10 @@ namespace Unreal_Binary_Builder
 		private bool SupportHTML5()
 		{
 			return EngineVersionSelection.SelectedIndex < 3;
+		}
+
+		private bool SupportLinuxAArch64() {
+			return EngineVersionSelection.SelectedIndex >= 3;
 		}
 	}
 }

--- a/Unreal Binary Builder/Properties/Settings.Designer.cs
+++ b/Unreal Binary Builder/Properties/Settings.Designer.cs
@@ -514,5 +514,17 @@ namespace Unreal_Binary_Builder.Properties {
                 this["EngineSelection"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool bWithLinuxAArch64 {
+            get {
+                return ((bool)(this["bWithLinuxAArch64"]));
+            }
+            set {
+                this["bWithLinuxAArch64"] = value;
+            }
+        }
     }
 }

--- a/Unreal Binary Builder/Properties/Settings.settings
+++ b/Unreal Binary Builder/Properties/Settings.settings
@@ -20,6 +20,9 @@
     <Setting Name="bWithLinux" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="bWithLinuxAArch64" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
     <Setting Name="bWithHTML5" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>


### PR DESCRIPTION
UE4 4.24 has a new platform, LinuxAArch64 that's activated by default. This adds the ability to switch it off.