### PR TITLE
Fix FinalBuildPath not being set at zip time

### DIFF
--- a/Unreal Binary Builder/MainWindow.xaml.cs
+++ b/Unreal Binary Builder/MainWindow.xaml.cs
@@ -32,7 +32,6 @@ namespace Unreal_Binary_Builder
 
         private string LogMessage = "";
 
-		private string FinalBuildPath = "";
 		private PostBuildSettings postBuildSettings = new PostBuildSettings();
 
         public MainWindow()
@@ -265,6 +264,7 @@ namespace Unreal_Binary_Builder
 			{
 				if (postBuildSettings.CanSaveToZip())
 				{
+					string FinalBuildPath = Path.GetFullPath(AutomationExePath).Replace(@"\Engine\Binaries\DotNET", @"\LocalBuilds\Engine").Replace(Path.GetFileName(AutomationExePath), "");
 					postBuildSettings.SaveToZip(this, FinalBuildPath, postBuildSettings.ZipPath.Text);
 					AddLogEntry("Saving zip file to " + postBuildSettings.ZipPath.Text);
 					WriteToLogFile();
@@ -316,7 +316,6 @@ namespace Unreal_Binary_Builder
                 {
                     BuildRocketUE.IsEnabled = true;
                     ChangeStatusLabel("Idle.");
-					FinalBuildPath = Path.GetFullPath(AutomationExePath).Replace(@"\Engine\Binaries\DotNET", @"\LocalBuilds\Engine").Replace(Path.GetFileName(AutomationExePath), "");
 				}
                 else
                 {


### PR DESCRIPTION
It was set after browsing to set the target path but not after loading settings when application starts.
Construct it at zip time instead