### PR TITLE
EnginePath Null Check

### DIFF
--- a/UnrealBinaryBuilder/MainWindow.xaml.cs
+++ b/UnrealBinaryBuilder/MainWindow.xaml.cs
@@ -235,6 +235,10 @@ namespace UnrealBinaryBuilder
 			{
 				foreach (EngineBuild engineBuild in Plugins.GetInstalledEngines())
 				{
+					if(engineBuild.EnginePath == null)
+					{
+						continue;
+					}
 					string RunUATFile = Path.Combine(engineBuild.EnginePath, "Engine", "Build", "BatchFiles", "RunUAT.bat");
 					if (File.Exists(RunUATFile))
 					{


### PR DESCRIPTION
If enginepath is null, app doesnt start and crash.

Added null check to line 238 .

(Recent Unreal 5EA to 5 update created a empty UE5EA EngineBuild that crashes program)